### PR TITLE
✨feat: Kafka Config & Consumer 로직 구현 (#3)

### DIFF
--- a/noti-service/src/main/java/com/waither/notiservice/NotiServiceApplication.java
+++ b/noti-service/src/main/java/com/waither/notiservice/NotiServiceApplication.java
@@ -2,8 +2,10 @@ package com.waither.notiservice;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class NotiServiceApplication {
 
     public static void main(String[] args) {

--- a/noti-service/src/main/java/com/waither/notiservice/config/KafkaConsumerConfig.java
+++ b/noti-service/src/main/java/com/waither/notiservice/config/KafkaConsumerConfig.java
@@ -1,0 +1,97 @@
+package com.waither.notiservice.config;
+
+import com.waither.notiservice.dto.UserDataDto;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.config.KafkaListenerContainerFactory;
+import org.springframework.kafka.core.*;
+import org.springframework.kafka.listener.ConcurrentMessageListenerContainer;
+import org.springframework.kafka.listener.ContainerProperties;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+@EnableKafka
+public class KafkaConsumerConfig {
+    @Value(value = "${spring.kafka.bootstrap-servers}")
+    private String bootstrapAddress;
+
+    @Value(value = "notice_1")
+    String groupId;
+
+    @Value(value = "earliest")
+    String autoOffsetResetStrategy;
+
+    @Value(value = "false")
+    String enableAutoCommit;
+
+    @Value(value = "5000")
+    String autoCommitIntervalMs;
+
+    @Value(value = "30000")
+    String sessionTimeoutMs;
+
+    @Value(value = "100")
+    String maxPollRecords;
+
+    @Bean
+    public ConsumerFactory<String, String> consumerFactory() {
+        Map<String, Object> props = new HashMap<>();
+
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapAddress);
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+        props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, enableAutoCommit);
+        props.put(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG, autoCommitIntervalMs);
+        props.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, sessionTimeoutMs);
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, autoOffsetResetStrategy);
+
+        return new DefaultKafkaConsumerFactory<>(props, new StringDeserializer(), new StringDeserializer());
+    }
+
+    @Bean
+    public KafkaListenerContainerFactory<ConcurrentMessageListenerContainer<String, String>>
+    kafkaListenerContainerFactory() {
+
+        ConcurrentKafkaListenerContainerFactory<String, String> factory =
+                new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory());
+        factory.setConcurrency(3);
+        factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.BATCH);
+        factory.getContainerProperties().setPollTimeout(3000); // max time to block in the consumer waiting for records
+        return factory;
+    }
+
+
+    @Bean("userDataKafkaListenerContainerFactory")
+    public ConcurrentKafkaListenerContainerFactory<String, UserDataDto> userDataKafkaListenerContainerFactory(){
+        ConcurrentKafkaListenerContainerFactory<String, UserDataDto> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(userConsumerFactory());
+        factory.setConcurrency(3);
+        factory.setBatchListener(true);
+        factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.BATCH);
+        return factory;
+    }
+
+    private ConsumerFactory<String, UserDataDto> userConsumerFactory() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapAddress);
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+        props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG,enableAutoCommit);
+        props.put(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG, autoCommitIntervalMs);
+        props.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, sessionTimeoutMs);
+        props.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, maxPollRecords);
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, autoOffsetResetStrategy);
+
+         return new DefaultKafkaConsumerFactory<>(props, new StringDeserializer(), new JsonDeserializer<>(UserDataDto.class));
+    }
+
+}

--- a/noti-service/src/main/java/com/waither/notiservice/config/KafkaConsumerConfig.java
+++ b/noti-service/src/main/java/com/waither/notiservice/config/KafkaConsumerConfig.java
@@ -26,22 +26,22 @@ public class KafkaConsumerConfig {
     private String bootstrapAddress;
 
     @Value(value = "notice_1")
-    String groupId;
+    private String groupId;
 
     @Value(value = "earliest")
-    String autoOffsetResetStrategy;
+    private String autoOffsetResetStrategy;
 
     @Value(value = "false")
-    String enableAutoCommit;
+    private String enableAutoCommit;
 
     @Value(value = "5000")
-    String autoCommitIntervalMs;
+    private String autoCommitIntervalMs;
 
     @Value(value = "30000")
-    String sessionTimeoutMs;
+    private String sessionTimeoutMs;
 
     @Value(value = "100")
-    String maxPollRecords;
+    private String maxPollRecords;
 
     @Bean
     public ConsumerFactory<String, String> consumerFactory() {

--- a/noti-service/src/main/java/com/waither/notiservice/config/KafkaTopicConfig.java
+++ b/noti-service/src/main/java/com/waither/notiservice/config/KafkaTopicConfig.java
@@ -1,0 +1,109 @@
+package com.waither.notiservice.config;
+
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.TopicBuilder;
+import org.springframework.kafka.core.KafkaAdmin;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaTopicConfig {
+
+    @Value(value = "${spring.kafka.bootstrap-servers}")
+    private String bootstrapAddress;
+
+
+    @Bean
+    public KafkaAdmin kafkaAdmin() {
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapAddress);
+        return new KafkaAdmin(configs);
+    }
+
+    /**
+     * <h2>userData 동기화 토픽</h2>
+     * @Producer : user-service
+     * @Consumer : noti-service
+     * @MessageFormat : "{"userId" : "{사용자 ID}", "level" : "{레벨}", "temperature" : "{온도}" }"
+     * @example : "{"userId" : "23", "level" : "2", "temperature" : "14.5" }"
+     * @Description : user-service의 userData 테이블과 noti-service의 테이블의 데이터를 동기화 하기 위해 사용합니다.
+     */
+    @Bean
+    public NewTopic userDataTopic(){
+        return TopicBuilder.name("user-data")
+                .partitions(1)
+                .replicas(1)
+                .build();
+    }
+
+    /**
+     * <h2>외출 시간 알림 토픽</h2>
+     * @Producer : user-service
+     * @Consumer : noti-service
+     * @MessageFormat : "{사용자 ID}, {사용자 맞춤 예보 on/off 여부}"
+     * @example : "23, true"
+     * @Description : 외출 시간 푸시 알림을 생성하기 위한 토픽입니다. 알림을 보낼 시간이 되면 메세지를 발행합니다.
+     */
+    @Bean
+    public NewTopic GoOutAlarmTopic(){
+        return TopicBuilder.name("alarm-go-out")
+                .partitions(1)
+                .replicas(1)
+                .build();
+    }
+
+    /**
+     * <h2>바람 세기 알림 토픽</h2>
+     * @Producer : weather-service
+     * @Consumer : noti-service
+     * @MessageFormat : "{바람 세기}"
+     * @example : "14.2"
+     * @Description : 매 주기 바람 세기를 메세지에 담아 발행합니다.
+     */
+    @Bean
+    public NewTopic WindAlarmTopic(){
+        return TopicBuilder.name("alarm-wind")
+                .partitions(1)
+                .replicas(1)
+                .build();
+    }
+
+    /**
+     * <h2>강설 정보 알림 토픽</h2>
+     * @Producer : weather-service
+     * @Consumer : noti-service
+     * @MessageFormat : "{강수량}" (확인 필요)
+     * @example : "0.03"
+     * @Description : 매 주기 강설 정보를 메세지에 담아 발행합니다.
+     */
+    @Bean
+    public NewTopic SnowAlarmTopic(){
+        return TopicBuilder.name("alarm-snow")
+                .partitions(1)
+                .replicas(1)
+                .build();
+    }
+
+    /**
+     * <h2>기상 특보 알림 토픽</h2>
+     * @Producer : weather-service
+     * @Consumer : noti-service
+     * @MessageFormat : "{기상 특보 메세지}"
+     * @example : "서울 전역 강풍 특보 발령"
+     * @Description : 기상 특보 메세지를 실시간으로 담아 발행합니다.
+     */
+    @Bean
+    public NewTopic climateAlarmTopic(){
+        return TopicBuilder.name("alarm-climate")
+                .partitions(1)
+                .replicas(1)
+                .build();
+    }
+
+
+}

--- a/noti-service/src/main/java/com/waither/notiservice/domain/Notification.java
+++ b/noti-service/src/main/java/com/waither/notiservice/domain/Notification.java
@@ -1,0 +1,25 @@
+package com.waither.notiservice.domain;
+
+import com.waither.notiservice.domain.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "notification")
+@Entity
+public class Notification extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private String id;
+
+    private String title;
+
+    private String content;
+
+    private Long userId;
+
+}

--- a/noti-service/src/main/java/com/waither/notiservice/domain/UserData.java
+++ b/noti-service/src/main/java/com/waither/notiservice/domain/UserData.java
@@ -1,15 +1,19 @@
 package com.waither.notiservice.domain;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.DynamicInsert;
 
 @Builder
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Table(name = "user_data")
+@DynamicInsert
 @Entity
 public class UserData {
 
@@ -17,10 +21,19 @@ public class UserData {
     private Long userId;
 
     // 각 답변의 평균 값 (level 1 쪽이 추움 ~ level 5 쪽이 더움)
+    @ColumnDefault(value = "34")
     private Double level1;
+
+    @ColumnDefault(value = "28")
     private Double level2;
+
+    @ColumnDefault(value = "24")
     private Double level3;
+
+    @ColumnDefault(value = "10")
     private Double level4;
+
+    @ColumnDefault(value = "7")
     private Double level5;
 
     public void setLevel(int level, Double value) {

--- a/noti-service/src/main/java/com/waither/notiservice/domain/UserData.java
+++ b/noti-service/src/main/java/com/waither/notiservice/domain/UserData.java
@@ -1,0 +1,35 @@
+package com.waither.notiservice.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.*;
+
+@Builder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "user_data")
+@Entity
+public class UserData {
+
+    @Id
+    private Long userId;
+
+    // 각 답변의 평균 값 (level 1 쪽이 추움 ~ level 5 쪽이 더움)
+    private Double level1;
+    private Double level2;
+    private Double level3;
+    private Double level4;
+    private Double level5;
+
+    public void setLevel(int level, Double value) {
+        switch (level) {
+            case 1 -> level1 = value;
+            case 2 -> level2 = value;
+            case 3 -> level3 = value;
+            case 4 -> level4 = value;
+            case 5 -> level5 = value;
+        }
+    }
+}

--- a/noti-service/src/main/java/com/waither/notiservice/domain/common/BaseEntity.java
+++ b/noti-service/src/main/java/com/waither/notiservice/domain/common/BaseEntity.java
@@ -1,0 +1,22 @@
+package com.waither.notiservice.domain.common;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/noti-service/src/main/java/com/waither/notiservice/dto/UserDataDto.java
+++ b/noti-service/src/main/java/com/waither/notiservice/dto/UserDataDto.java
@@ -1,0 +1,22 @@
+package com.waither.notiservice.dto;
+
+import com.waither.notiservice.domain.UserData;
+import lombok.Getter;
+
+@Getter
+public class UserDataDto {
+
+    public Long userId;
+
+    public Integer level;
+
+    public Double temperature;
+
+    public UserData toEntity() {
+        UserData userData = UserData.builder()
+                .userId(userId)
+                .build();
+        userData.setLevel(level, temperature);
+        return userData;
+    }
+}

--- a/noti-service/src/main/java/com/waither/notiservice/repository/UserDataRepository.java
+++ b/noti-service/src/main/java/com/waither/notiservice/repository/UserDataRepository.java
@@ -1,0 +1,9 @@
+package com.waither.notiservice.repository;
+
+import com.waither.notiservice.domain.UserData;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserDataRepository extends JpaRepository<UserData, Long> {
+}

--- a/noti-service/src/main/java/com/waither/notiservice/service/KafkaConsumerService.java
+++ b/noti-service/src/main/java/com/waither/notiservice/service/KafkaConsumerService.java
@@ -1,0 +1,128 @@
+package com.waither.notiservice.service;
+
+import com.waither.notiservice.domain.UserData;
+import com.waither.notiservice.dto.UserDataDto;
+import com.waither.notiservice.repository.UserDataRepository;
+import com.waither.notiservice.utils.TemperatureUtils;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.StringTokenizer;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class KafkaConsumerService {
+
+    private final UserDataRepository userDataRepository;
+
+    /**
+     * 사용자 데이터 동기화 Listener
+     * */
+    @KafkaListener(topics = "user-data", containerFactory = "userDataKafkaListenerContainerFactory")
+    public void consumeUserData(UserDataDto userDataDto) {
+      log.info("[ Kafka Listener ] User Data 동기화");
+      log.info("[ Kafka Listener ] User ID : --> {}", userDataDto.getUserId());
+      log.info("[ Kafka Listener ] LEVEL : --> {}", userDataDto.getLevel());
+      log.info("[ Kafka Listener ] TEMP : --> {}", userDataDto.getTemperature());
+
+        Optional<UserData> userData = userDataRepository.findById(userDataDto.userId);
+        if (userData.isPresent()) {
+            userData.get().setLevel(userDataDto.getLevel(), userDataDto.getTemperature());
+        } else {
+            userDataRepository.save(userDataDto.toEntity());
+        }
+    }
+
+    /**
+     * 외출 알림 Listener
+     * */
+    @KafkaListener(topics = "alarm-go-out")
+    public void consumeGoOutAlarm(@Payload String message) {
+        StringTokenizer st = new StringTokenizer(message, ", ");
+        String resultMessage = "";
+        Long userId = Long.valueOf(st.nextToken());
+        boolean isUserAlert = Boolean.parseBoolean(st.nextToken());
+
+
+        log.info("[ Kafka Listener ] 사용자 아침 알림");
+        log.info("[ Kafka Listener ] User ID : --> {}", userId);
+        log.info("[ Kafka Listener ] userAlert : --> {}", isUserAlert);
+
+        //TODO : 하루 날씨 정보 가져오기
+        double avgTemp = 2.5;
+
+        //TODO : 사용자 닉네임 가져오기
+        resultMessage += "진호님, 오늘 날씨는 ";
+
+        UserData userData = userDataRepository.findById(userId)
+                //TODO : Custom Exception
+                .orElseThrow(RuntimeException::new);
+        resultMessage += TemperatureUtils.createUserDataMessage(userData, avgTemp);
+
+        //TODO : 날씨 요약
+        resultMessage += "오후 6시에 비가 올 예정이예요. 우산을 챙겨가세요.";
+
+        //TODO : 푸시알림 전송
+
+    }
+
+    /**
+     * 바람 세기 알림 Listener
+     * */
+    @KafkaListener(topics = "alarm-wind")
+    public void consumeWindAlarm(@Payload String message) {
+        String resultMessage = "";
+        Long windStrength = Long.valueOf(message); //바람세기
+
+        log.info("[ Kafka Listener ] 바람 세기");
+        log.info("[ Kafka Listener ] Wind Strength : --> {}", windStrength);
+
+        //TODO : 알림 보낼 사용자 정보 가져오기 (Redis)
+        List<Long> userIds = new ArrayList<>();
+
+        //TODO : 바람 세기 알림 멘트 정리
+        resultMessage += "현재 바람 세기가 " + windStrength + "m/s 이상입니다. 강풍에 주의하세요.";
+
+        //TODO : 푸시알림 전송
+        String finalResultMessage = resultMessage;
+        userIds.forEach(id ->{
+
+            System.out.println("[ 푸시알림 ] 바람 세기 알림");
+            System.out.printf("[ 푸시알림 ] userId ---> {%d}", id);
+            System.out.printf("[ 푸시알림 ] message ---> {%s}", finalResultMessage);
+        });
+
+    }
+
+    /**
+     * 기상 특보 알림 Listener
+     * */
+    @KafkaListener(topics = "alarm-climate")
+    public void consumeClimateAlarm(@Payload String message) {
+        String resultMessage = "";
+
+        log.info("[ Kafka Listener ] 기상 특보");
+
+        //TODO : 알림 보낼 사용자 정보 가져오기 (Redis)
+        List<Long> userIds = new ArrayList<>();
+
+        resultMessage += "[기상청 기상 특보] " + message;
+
+        //TODO : 푸시알림 전송
+        String finalResultMessage = resultMessage;
+        userIds.forEach(id ->{
+
+            System.out.println("[ 푸시알림 ] 기상 특보 알림");
+            System.out.printf("[ 푸시알림 ] userId ---> {%d}", id);
+            System.out.printf("[ 푸시알림 ] message ---> {%s}", finalResultMessage);
+        });
+
+    }
+}

--- a/noti-service/src/main/java/com/waither/notiservice/utils/TemperatureUtils.java
+++ b/noti-service/src/main/java/com/waither/notiservice/utils/TemperatureUtils.java
@@ -1,0 +1,31 @@
+package com.waither.notiservice.utils;
+
+import com.waither.notiservice.domain.UserData;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class TemperatureUtils {
+
+    public static String createUserDataMessage(UserData userData, double temperature) {
+        double medianBetween1And2 = (userData.getLevel1() + userData.getLevel2()) / 2;
+        double medianBetween2And3 = (userData.getLevel2() + userData.getLevel3()) / 2;
+        double medianBetween3And4 = (userData.getLevel3() + userData.getLevel4()) / 2;
+        double medianBetween4And5 = (userData.getLevel4() + userData.getLevel5()) / 2;
+
+        //TODO : 계절별 멘트 정리
+        if (temperature < medianBetween1And2) {
+            return "더우실거예요.";
+        } else if (medianBetween1And2 <= temperature && temperature < medianBetween2And3) {
+            return "조금 더우실거예요.";
+        }else if (medianBetween2And3 <= temperature && temperature < medianBetween3And4) {
+            return "좋을거예요.";
+        }else if (medianBetween3And4 <= temperature && temperature < medianBetween4And5) {
+            return "조금 추울거예요.";
+        }else if (medianBetween4And5 <= temperature) {
+            return "추울거예요.";
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
# ☝️Issue Number

- #3 

# 🔎 Key Changes
- Kafka Setting
- Notification, UserData 엔티티 생성
- 아침 푸시 알림 Consumer 로직 구현
- 상시 푸시 알림 Consumer 로직 구현

# 💌 To Reviewers ‼️필독‼️
- WebClient 추상화는 다른 이슈로 빼겠습니다.
- Kafka Topic 생성을 noti-service에서 구현했습니다. 다른 서비스들은 메세지 발행만 하시면 되겠습니다.
- 메세지 발행 형식은 KafkaTopicConfig.java 에 명시되어 있는 주석을 참고해 주세요.
- KakfaProducer 설정하는 코드는 곧 공유하겠습니다. 사용 방법도 곧 공유 하겠습니다.

