### PR TITLE
📝 docs: API 문서 통합화 (#44)

### DIFF
--- a/.github/workflows/apiDocs.yml
+++ b/.github/workflows/apiDocs.yml
@@ -45,5 +45,6 @@ jobs:
       - name: Commit and push build artifacts
         run: |
           git add .
+          git add remote origin ${{ secrets.REPOSITORY_URL }}
           git commit -m "📝docs : Generate API Docs"
           git push origin apiDocs

--- a/.github/workflows/apiDocs.yml
+++ b/.github/workflows/apiDocs.yml
@@ -23,21 +23,21 @@ jobs:
       - name: redoc-cli-github-action
         uses: seeebiii/redoc-cli-github-action@v9
         with:
-          args: 'bundle noti.json --output noti.yaml --ext yaml'
+          args: 'bundle ./noti.json --output ./noti.yaml --ext yaml'
 
       - name: Rename Yaml Title & Desc
         run: |
-          yq -i '.info.title = "PetStore Backend API Document for FrontEnd"' fe.yaml
-          yq -i '.info.description = "Please contact Petstore backend if there are any issues with API"' fe.yaml
+          yq -i '.info.title = "PetStore Backend API Document for FrontEnd"' ./noti.yaml
+          yq -i '.info.description = "Please contact Petstore backend if there are any issues with API"' ./noti.yaml
 
       - name: redoc-cli-github-action
         uses: seeebiii/redoc-cli-github-action@v9
         with:
-          args: 'build-docs noti.yaml --output api-docs.html'
+          args: 'build-docs ./noti.yaml --output ./api-docs.html'
 
       - name: save build result to tmp dir
         run: |
-          cd ..
+          cd ../..
           mkdir -p docs
           mv ./noti-service/api-docs.html .
         

--- a/.github/workflows/apiDocs.yml
+++ b/.github/workflows/apiDocs.yml
@@ -38,6 +38,9 @@ jobs:
 
       - name: save build result to tmp dir
         run: |
+          ls -all
+          pwd
+          ls ./noti-service/docs
           mkdir -p docs
           mv ./noti-serivce/docs/api-docs.html ./docs
         

--- a/.github/workflows/apiDocs.yml
+++ b/.github/workflows/apiDocs.yml
@@ -23,7 +23,7 @@ jobs:
       - name: redoc-cli-github-action
         uses: seeebiii/redoc-cli-github-action@v9
         with:
-          args: 'bundle ./noti.json --output ./noti.yaml --ext yaml'
+          args: 'bundle ./noti-service/docs/noti.json --output ./noti-service/docs/noti.yaml --ext yaml'
 
       - name: Rename Yaml Title & Desc
         run: |

--- a/.github/workflows/apiDocs.yml
+++ b/.github/workflows/apiDocs.yml
@@ -38,11 +38,8 @@ jobs:
 
       - name: save build result to tmp dir
         run: |
-          ls -all
-          pwd
-          ls ./noti-service/docs
           mkdir -p docs
-          mv ./noti-serivce/docs/api-docs.html ./docs
+          mv ./noti-service/docs/api-docs.html ./docs
         
 
       - name: Commit and push build artifacts

--- a/.github/workflows/apiDocs.yml
+++ b/.github/workflows/apiDocs.yml
@@ -48,4 +48,5 @@ jobs:
           git config --global user.email "gsu9045000@gmail.com"
           git add .
           git commit -m "📝docs : Generate API Docs"
-          git push ${{ secrets.REPOSITORY_URL }} HEAD:apiDocs
+          git remote set-url origin ${{ secrets.REPOSITORY_URL }}
+          git push origin apiDocs

--- a/.github/workflows/apiDocs.yml
+++ b/.github/workflows/apiDocs.yml
@@ -45,6 +45,6 @@ jobs:
       - name: Commit and push build artifacts
         run: |
           git add .
-          git add remote origin ${{ secrets.REPOSITORY_URL }}
+          git remote add origin ${{ secrets.REPOSITORY_URL }}
           git commit -m "📝docs : Generate API Docs"
           git push origin apiDocs

--- a/.github/workflows/apiDocs.yml
+++ b/.github/workflows/apiDocs.yml
@@ -16,17 +16,16 @@ jobs:
         with:
           ref: 'docs/#44'
 
-      - name: generate document html
+      - name: move to docs directory
         run: |
-          cd ./noti-service
-          cp noti-service/docs/noti.json ./
+          cd ./noti-service/docs
 
       - name: redoc-cli-github-action
         uses: seeebiii/redoc-cli-github-action@v9
         with:
           args: 'bundle noti.json --output noti.yaml --ext yaml'
 
-      - name: generate document html
+      - name: Rename Yaml Title & Desc
         run: |
           yq -i '.info.title = "PetStore Backend API Document for FrontEnd"' fe.yaml
           yq -i '.info.description = "Please contact Petstore backend if there are any issues with API"' fe.yaml
@@ -42,10 +41,6 @@ jobs:
           mkdir -p docs
           mv ./noti-service/api-docs.html .
         
-      - name: Checkout document branch
-        uses: actions/checkout@v3
-        with:
-          ref: 'main'
 
       - name: Commit and push build artifacts
         run: |

--- a/.github/workflows/apiDocs.yml
+++ b/.github/workflows/apiDocs.yml
@@ -40,7 +40,11 @@ jobs:
         run: |
           mkdir -p docs
           mv ./noti-service/docs/api-docs.html ./docs
-        
+
+      - name: Install SSH Key
+        uses: webfactory/ssh-agent@v0.5.0
+        with:
+          ssh-private-key: ${{ secrets.DEPLOY_KEY }}
 
       - name: Commit and push build artifacts
         run: |        
@@ -48,5 +52,4 @@ jobs:
           git config --global user.email "gsu9045000@gmail.com"
           git add .
           git commit -m "📝docs : Generate API Docs"
-          git remote set-url origin ${{ secrets.REPOSITORY_URL }}
-          git push origin apiDocs
+          git push https://git@github.com/WaitherTeam/Waither-BE.git HEAD:apiDocs

--- a/.github/workflows/apiDocs.yml
+++ b/.github/workflows/apiDocs.yml
@@ -1,0 +1,54 @@
+name: API Docs Integration
+
+on:
+  push:
+    branches:
+      - docs/#44
+
+jobs:
+  document:
+    runs-on: ubuntu-latest
+    steps:
+
+      # 프로젝트 코드를 가져옵니다.
+      - name: Checkout Code 
+        uses: actions/checkout@v3
+        with:
+          ref: 'docs/#44'
+
+      - name: generate document html
+        run: |
+          cd ./noti-service
+          cp noti-service/docs/noti.json ./
+
+      - name: redoc-cli-github-action
+        uses: seeebiii/redoc-cli-github-action@v9
+        with:
+          args: 'bundle noti.json --output noti.yaml --ext yaml'
+
+      - name: generate document html
+        run: |
+          yq -i '.info.title = "PetStore Backend API Document for FrontEnd"' fe.yaml
+          yq -i '.info.description = "Please contact Petstore backend if there are any issues with API"' fe.yaml
+
+      - name: redoc-cli-github-action
+        uses: seeebiii/redoc-cli-github-action@v9
+        with:
+          args: 'build-docs noti.yaml --output api-docs.html'
+
+      - name: save build result to tmp dir
+        run: |
+          cd ..
+          mkdir -p docs
+          mv ./noti-service/api-docs.html .
+        
+      - name: Checkout document branch
+        uses: actions/checkout@v3
+        with:
+          ref: 'main'
+
+      - name: Commit and push build artifacts
+        run: |
+          git add .
+          git commit -m "📝docs : Generate API Docs"
+          git push origin apiDocs

--- a/.github/workflows/apiDocs.yml
+++ b/.github/workflows/apiDocs.yml
@@ -16,10 +16,7 @@ jobs:
         with:
           ref: 'docs/#44'
 
-      # - name: move to docs directory
-      #   run: |
-      #     cd ./noti-service/docs
-
+      # Redoc : json 파일을 가져와 bundle
       - name: redoc-cli-github-action
         uses: seeebiii/redoc-cli-github-action@v9
         with:
@@ -36,24 +33,13 @@ jobs:
       #   with:
       #     args: 'build-docs ./noti-serivce/docs/noti.yaml --output ./noti-serivce/docs/api-docs.html'
 
+      # 완성된 html 파일을 docs 디렉토리에 놓습니다.
       - name: save build result to tmp dir
         run: |
           mkdir -p docs
           mv ./noti-service/docs/index.html ./docs
 
-      - name: Install SSH Key
-        uses: webfactory/ssh-agent@v0.5.0
-        with:
-          ssh-private-key: ${{ secrets.DEPLOY_KEY }}
-
-      # - name: Commit and push build artifacts
-      #   run: |        
-      #     git config --global user.name "DDonghyeo"
-      #     git config --global user.email "gsu9045000@gmail.com"
-      #     git add .
-      #     git commit -m "📝docs : Generate API Docs"
-      #     git push https://git@github.com/WaitherTeam/Waither-BE.git HEAD:apiDocs
-
+      # 웹페이지 Repository에 Push 합니다.
       - name: Install SSH Key
         uses: leigholiver/commit-with-deploy-key@v1.0.4
         with:

--- a/.github/workflows/apiDocs.yml
+++ b/.github/workflows/apiDocs.yml
@@ -16,9 +16,9 @@ jobs:
         with:
           ref: 'docs/#44'
 
-      - name: move to docs directory
-        run: |
-          cd ./noti-service/docs
+      # - name: move to docs directory
+      #   run: |
+      #     cd ./noti-service/docs
 
       - name: redoc-cli-github-action
         uses: seeebiii/redoc-cli-github-action@v9
@@ -27,19 +27,18 @@ jobs:
 
       - name: Rename Yaml Title & Desc
         run: |
-          yq -i '.info.title = "PetStore Backend API Document for FrontEnd"' ./noti.yaml
-          yq -i '.info.description = "Please contact Petstore backend if there are any issues with API"' ./noti.yaml
+          yq -i '.info.title = "PetStore Backend API Document for FrontEnd"' ./noti-service/docs/noti.yaml
+          yq -i '.info.description = "Please contact Petstore backend if there are any issues with API"' ./noti-service/docs/noti.yaml
 
       - name: redoc-cli-github-action
         uses: seeebiii/redoc-cli-github-action@v9
         with:
-          args: 'build-docs ./noti.yaml --output ./api-docs.html'
+          args: 'build-docs ./noti-serivce/docs/noti.yaml --output ./api-docs.html'
 
       - name: save build result to tmp dir
         run: |
-          cd ../..
           mkdir -p docs
-          mv ./noti-service/api-docs.html .
+          mv ./api-docs.html ./docs
         
 
       - name: Commit and push build artifacts

--- a/.github/workflows/apiDocs.yml
+++ b/.github/workflows/apiDocs.yml
@@ -46,10 +46,19 @@ jobs:
         with:
           ssh-private-key: ${{ secrets.DEPLOY_KEY }}
 
-      - name: Commit and push build artifacts
-        run: |        
-          git config --global user.name "DDonghyeo"
-          git config --global user.email "gsu9045000@gmail.com"
-          git add .
-          git commit -m "📝docs : Generate API Docs"
-          git push https://git@github.com/WaitherTeam/Waither-BE.git HEAD:apiDocs
+      # - name: Commit and push build artifacts
+      #   run: |        
+      #     git config --global user.name "DDonghyeo"
+      #     git config --global user.email "gsu9045000@gmail.com"
+      #     git add .
+      #     git commit -m "📝docs : Generate API Docs"
+      #     git push https://git@github.com/WaitherTeam/Waither-BE.git HEAD:apiDocs
+
+      - name: Install SSH Key
+        uses: leigholiver/commit-with-deploy-key@v1.0.4
+        with:
+          source: ./docs/api-docs.html
+          destination_folder: docs
+          destination_repo: WaitherTeam/Waither-BE
+          destination_branch: apiDocs
+          deploy_key: ${{ secrets.DEPLOY_KEY }}

--- a/.github/workflows/apiDocs.yml
+++ b/.github/workflows/apiDocs.yml
@@ -25,11 +25,11 @@ jobs:
         with:
           args: 'bundle ./noti-service/docs/noti.json --output ./noti-service/docs/noti.yaml --ext yaml'
 
-      - name: Rename Yaml Title & Desc
-        run: |
-          cat ./noti-service/docs/noti.yaml
-          yq -i '.info.title = "PetStore Backend API Document for FrontEnd"' ./noti-service/docs/noti.yaml
-          yq -i '.info.description = "Please contact Petstore backend if there are any issues with API"' ./noti-service/docs/noti.yaml
+      # - name: Rename Yaml Title & Desc
+      #   run: |
+      #     cat ./noti-service/docs/noti.yaml
+      #     yq -i '.info.title = "PetStore Backend API Document for FrontEnd"' ./noti-service/docs/noti.yaml
+      #     yq -i '.info.description = "Please contact Petstore backend if there are any issues with API"' ./noti-service/docs/noti.yaml
 
       - name: redoc-cli-github-action
         uses: seeebiii/redoc-cli-github-action@v9

--- a/.github/workflows/apiDocs.yml
+++ b/.github/workflows/apiDocs.yml
@@ -43,9 +43,8 @@ jobs:
         
 
       - name: Commit and push build artifacts
-        run: |
-          git config --global user.email "gsu9045000@gmail.com"
-          git config --global user.name "DDonghyeo"
+        run: |        
+          git config --global user.name "WaitherTeam"
           git add .
           git commit -m "📝docs : Generate API Docs"
           git push ${{ secrets.REPOSITORY_URL }} HEAD:apiDocs

--- a/.github/workflows/apiDocs.yml
+++ b/.github/workflows/apiDocs.yml
@@ -23,7 +23,7 @@ jobs:
       - name: redoc-cli-github-action
         uses: seeebiii/redoc-cli-github-action@v9
         with:
-          args: 'bundle ./noti-service/docs/noti.json --output ./noti-service/docs/noti.yaml --ext yaml'
+          args: 'bundle ./noti-service/docs/noti.json --output ./noti-service/docs/api-docs.html --ext html'
 
       # - name: Rename Yaml Title & Desc
       #   run: |
@@ -31,10 +31,10 @@ jobs:
       #     yq -i '.info.title = "PetStore Backend API Document for FrontEnd"' ./noti-service/docs/noti.yaml
       #     yq -i '.info.description = "Please contact Petstore backend if there are any issues with API"' ./noti-service/docs/noti.yaml
 
-      - name: redoc-cli-github-action
-        uses: seeebiii/redoc-cli-github-action@v9
-        with:
-          args: 'build-docs ./noti-serivce/docs/noti.yaml --output ./noti-serivce/docs/api-docs.html'
+      # - name: redoc-cli-github-action
+      #   uses: seeebiii/redoc-cli-github-action@v9
+      #   with:
+      #     args: 'build-docs ./noti-serivce/docs/noti.yaml --output ./noti-serivce/docs/api-docs.html'
 
       - name: save build result to tmp dir
         run: |

--- a/.github/workflows/apiDocs.yml
+++ b/.github/workflows/apiDocs.yml
@@ -47,6 +47,7 @@ jobs:
           git config --global user.email "gsu9045000@gmail.com"
           git config --global user.name "DDonghyeo"
           git add .
+          git checkout apiDocs
           git remote add norigin ${{ secrets.REPOSITORY_URL }}
           git commit -m "📝docs : Generate API Docs"
           git push norigin apiDocs

--- a/.github/workflows/apiDocs.yml
+++ b/.github/workflows/apiDocs.yml
@@ -44,7 +44,8 @@ jobs:
 
       - name: Commit and push build artifacts
         run: |        
-          git config --global user.name "WaitherTeam"
+          git config --global user.name "DDonghyeo"
+          git config --global user.email "gsu9045000@gmail.com"
           git add .
           git commit -m "📝docs : Generate API Docs"
           git push ${{ secrets.REPOSITORY_URL }} HEAD:apiDocs

--- a/.github/workflows/apiDocs.yml
+++ b/.github/workflows/apiDocs.yml
@@ -47,7 +47,5 @@ jobs:
           git config --global user.email "gsu9045000@gmail.com"
           git config --global user.name "DDonghyeo"
           git add .
-          git checkout apiDocs
-          git remote add norigin ${{ secrets.REPOSITORY_URL }}
           git commit -m "📝docs : Generate API Docs"
-          git push norigin apiDocs
+          git push ${{ secrets.REPOSITORY_URL }} HEAD:apiDocs

--- a/.github/workflows/apiDocs.yml
+++ b/.github/workflows/apiDocs.yml
@@ -44,6 +44,8 @@ jobs:
 
       - name: Commit and push build artifacts
         run: |
+          git config --global user.email "gsu9045000@gmail.com"
+          git config --global user.name "DDonghyeo"
           git add .
           git remote add norigin ${{ secrets.REPOSITORY_URL }}
           git commit -m "📝docs : Generate API Docs"

--- a/.github/workflows/apiDocs.yml
+++ b/.github/workflows/apiDocs.yml
@@ -34,12 +34,12 @@ jobs:
       - name: redoc-cli-github-action
         uses: seeebiii/redoc-cli-github-action@v9
         with:
-          args: 'build-docs ./noti-serivce/docs/noti.yaml --output ./api-docs.html'
+          args: 'build-docs ./noti-serivce/docs/noti.yaml --output ./noti-serivce/docs/api-docs.html'
 
       - name: save build result to tmp dir
         run: |
           mkdir -p docs
-          mv ./api-docs.html ./docs
+          mv ./noti-serivce/docs/api-docs.html ./docs
         
 
       - name: Commit and push build artifacts

--- a/.github/workflows/apiDocs.yml
+++ b/.github/workflows/apiDocs.yml
@@ -59,6 +59,6 @@ jobs:
         with:
           source: ./docs/index.html
           destination_folder: docs
-          destination_repo: WaitherTeam/api-docs.io
+          destination_repo: WaitherTeam/WaitherTeam.github.io
           destination_branch: main
           deploy_key: ${{ secrets.DEPLOY_KEY }}

--- a/.github/workflows/apiDocs.yml
+++ b/.github/workflows/apiDocs.yml
@@ -45,6 +45,6 @@ jobs:
       - name: Commit and push build artifacts
         run: |
           git add .
-          git remote add origin ${{ secrets.REPOSITORY_URL }}
+          git remote add norigin ${{ secrets.REPOSITORY_URL }}
           git commit -m "📝docs : Generate API Docs"
-          git push origin apiDocs
+          git push norigin apiDocs

--- a/.github/workflows/apiDocs.yml
+++ b/.github/workflows/apiDocs.yml
@@ -27,6 +27,7 @@ jobs:
 
       - name: Rename Yaml Title & Desc
         run: |
+          cat ./noti-service/docs/noti.yaml
           yq -i '.info.title = "PetStore Backend API Document for FrontEnd"' ./noti-service/docs/noti.yaml
           yq -i '.info.description = "Please contact Petstore backend if there are any issues with API"' ./noti-service/docs/noti.yaml
 

--- a/.github/workflows/apiDocs.yml
+++ b/.github/workflows/apiDocs.yml
@@ -23,7 +23,7 @@ jobs:
       - name: redoc-cli-github-action
         uses: seeebiii/redoc-cli-github-action@v9
         with:
-          args: 'bundle ./noti-service/docs/noti.json --output ./noti-service/docs/api-docs.html --ext html'
+          args: 'bundle ./noti-service/docs/noti.json --output ./noti-service/docs/index.html --ext html'
 
       # - name: Rename Yaml Title & Desc
       #   run: |
@@ -39,7 +39,7 @@ jobs:
       - name: save build result to tmp dir
         run: |
           mkdir -p docs
-          mv ./noti-service/docs/api-docs.html ./docs
+          mv ./noti-service/docs/index.html ./docs
 
       - name: Install SSH Key
         uses: webfactory/ssh-agent@v0.5.0
@@ -57,8 +57,8 @@ jobs:
       - name: Install SSH Key
         uses: leigholiver/commit-with-deploy-key@v1.0.4
         with:
-          source: ./docs/api-docs.html
+          source: ./docs/index.html
           destination_folder: docs
-          destination_repo: WaitherTeam/Waither-BE
-          destination_branch: apiDocs
+          destination_repo: WaitherTeam/api-docs.io
+          destination_branch: main
           deploy_key: ${{ secrets.DEPLOY_KEY }}

--- a/noti-service/build.gradle
+++ b/noti-service/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.2.3'
     id 'io.spring.dependency-management' version '1.1.4'
+    id "org.springdoc.openapi-gradle-plugin" version '1.8.0'
 }
 
 group = 'com.waither'
@@ -48,12 +49,24 @@ dependencies {
     //Redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
-    //Swagger
+    //Springdoc
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
+    //implementation 'org.springdoc:springdoc-openapi-gradle-plugin:1.8.0'
 
     //JUnit + AssertJ
     testImplementation 'org.junit.jupiter:junit-jupiter:5.8.2'
     testImplementation 'org.assertj:assertj-core:3.23.1'
+}
+
+openApi {
+    apiDocsUrl.set("http://localhost:80") // Document URL
+    outputDir.set(file("$rootDir/build/docs")) // Build Result Path
+    outputFileName.set("noti.json") // Build Result File Name
+    groupedApiMappings.set(Map.of("http://localhost:8082/noti/api-docs", "noti.json"))
+    waitTimeInSeconds.set(60) // Timeout
+    customBootRun {
+        args.add("--spring.profiles.active=dev")
+    }
 }
 
 dependencyManagement {
@@ -65,3 +78,4 @@ dependencyManagement {
 tasks.named('test') {
     useJUnitPlatform()
 }
+

--- a/noti-service/docs/noti.json
+++ b/noti-service/docs/noti.json
@@ -1,0 +1,177 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "noti-service API",
+    "description": "Waither noti-service API 명세서입니다.",
+    "version": "v0.0.1"
+  },
+  "servers": [
+    {
+      "url": "/"
+    }
+  ],
+  "paths": {
+    "/api/v1/noti/goOut": {
+      "post": {
+        "tags": [
+          "notification-controller"
+        ],
+        "summary": "Send Go Out Alarm",
+        "description": "외출 알림 전송하기",
+        "operationId": "sendGoOutAlarm",
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "500": {
+            "description": "INTERNAL SERVER ERROR"
+          },
+          "200": {
+            "description": "OK"
+          },
+          "404": {
+            "description": "NOT FOUND"
+          },
+          "400": {
+            "description": "BAD REQUEST"
+          }
+        }
+      }
+    },
+    "/api/v1/noti/": {
+      "post": {
+        "tags": [
+          "notification-controller"
+        ],
+        "operationId": "checkCurrentAlarm",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LocationDto"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/noti": {
+      "get": {
+        "tags": [
+          "notification-controller"
+        ],
+        "summary": "get notification",
+        "description": "알림 목록 조회하기",
+        "operationId": "getNotifications",
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "500": {
+            "description": "INTERNAL SERVER ERROR",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NotificationResponse"
+                  }
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotificationResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NOT FOUND",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NotificationResponse"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "BAD REQUEST",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NotificationResponse"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "LocationDto": {
+        "type": "object",
+        "properties": {
+          "x": {
+            "type": "number",
+            "format": "double"
+          },
+          "y": {
+            "type": "number",
+            "format": "double"
+          }
+        }
+      },
+      "NotificationResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "time": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "message": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
# ☝️Issue Number

- #44 

# 🔎 Key Changes
- API 명세 통합 스크립트
- openapi 명세서 생성 추가

# 💌 To Reviewers

## api 문서 추출 방법

- build.gradle 추가

1. 플러그인 추가

```java
plugins {
    id "org.springdoc.openapi-gradle-plugin" version '1.8.0'
}
```

2. openapi 의존성 추가

```java

dependencies {

    //Springdoc
    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
}

```

- yml 설정

```yml
springdoc:
  webjars:
    prefix:
  api-docs:
    path: /noti/api-docs
    groups:
      enabled: true
  swagger-ui:
    path: /noti/swagger
    configUrl: /noti/api-docs/swagger-config
    disable-swagger-default-url: true
```


api 명세서의 path를 설정해 둡니다.

위에서 정의한 path를 기준으로 build.gradle에 다음을 추가합니다.


```java
openApi {
    apiDocsUrl.set("http://localhost:3000") // Document URL
    outputDir.set(file("$rootDir/docs")) // Build Result Path
    outputFileName.set("noti.json") // Build Result File Name
    groupedApiMappings.set(Map.of("http://localhost:8082/noti/api-docs", "noti.json"))
    waitTimeInSeconds.set(60) // Timeout
    customBootRun {
        args.add("--spring.profiles.active=dev")
    }
}
```

yml에서 설정한 path를 위 groupedApiMappings 에 세팅합니다.


- gradle task 실행

여기까지 하셨다면, gradle 에 generateOpenApiDocs task가 생성됩니다.
<img width="318" alt="image" src="https://github.com/WaitherTeam/Waither-BE/assets/98632435/ae9514f3-cb4d-4c82-b9cc-3bdd22b40568">

위 task를 누르거나, ./grdalew generateOpenApiDocs 를 하시면 됩니다.


task를 실행하면, /docs 디렉토리에 json파일이 생깁니다.

여기까지 하시면 Github Action이 통합하겠습니다.
