### PR TITLE
💚 ci/cd: 배포 환경 구축 (#61)

### DIFF
--- a/.github/workflows/apiDocs.yml
+++ b/.github/workflows/apiDocs.yml
@@ -1,10 +1,9 @@
-name: API Docs Integration
+name: api-docs-integration
 
 on:
   push:
     branches:
       - develop
-      - cicd/#61
 
 jobs:
   api-docs-integration:

--- a/.github/workflows/apiDocs.yml
+++ b/.github/workflows/apiDocs.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - develop
+      - cicd/#61
 
 jobs:
   api-docs-integration:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -7,10 +7,10 @@ on:
         description: 'Service to deploy. Default is all \n options : \n - api-gateway \n - noti-service \n - user-service \n - weather-service \n - all'
         required: true
         default: 'all'
-  push:
-    branches:
-      - cicd/#61
-      - prod
+  # push:
+  #   branches:
+  #     - cicd/#61
+  #     - prod
 
 jobs:
   build:
@@ -127,7 +127,7 @@ jobs:
           port: ${{ secrets.EC2_SSH_PORT }}
           timeout: 60s
           script: |
-            export CONFIG_GIT_URI = ${{ secrets.DOCKERHUB_IMAGENAME }}
+            export CONFIG_GIT_URI = ${{ secrets.CONFIG_GIT_URI }}
             export CONFIG_PASSPHRASE = ${{ secrets.CONFIG_PASSPHRASE }}
             export CONFIG_PRIVATE_KEY = ${{ secrets.CONFIG_PRIVATE_KEY }}
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,136 @@
+name: Backend CI/CD with Gradle
+
+on:
+  workflow_dispatch:
+    inputs:
+      service:
+        description: 'Service to deploy. Default is all \n options : \n - api-gateway \n - noti-service \n - user-service \n - weather-service \n - all'
+        required: true
+        default: 'all'
+  push:
+    branches:
+      - cicd/#61
+      - prod
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    
+    #Checkout : 코드 가져오기
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      #Setting JDK
+      - name: Set up JDK 17
+        uses: actions/setup-java@v2
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      #gradlew chmod
+      - name: Grant execute permission for gradlew
+        run: |
+          chmod +x ./apiGateway-service/gradlew
+          chmod +x ./config-service/gradlew
+          chmod +x ./Eureka/gradlew
+          chmod +x ./noti-service/gradlew
+          chmod +x ./user-service/gradlew
+          chmod +x ./weather-service/gradlew
+
+      # DockerHub Login
+      - name: Docker Hub Login
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      #Config-Service Build & Docker Push
+      - name: Build with Gradle - config
+        run: |
+          cd config-service
+          ./gradlew clean build -x test
+          docker build -t ${{ secrets.DOCKERHUB_USERNAME }}/waither-config .
+          docker push ${{ secrets.DOCKERHUB_USERNAME }}/waither-config
+        env:
+          CONFIG_GIT_URI: ${{ secrets.CONFIG_GIT_URI }}
+          CONFIG_PASSPHRASE: ${{ secrets.CONFIG_PASSPHRASE }}
+          CONFIG_PRIVATE_KEY: ${{ secrets.CONFIG_PRIVATE_KEY }}
+
+      #Config-Service Run
+      - name: Run config-service
+        run: |
+          ./gradlew bootRun &
+          cd ..
+      #Wait 5 sec
+      - name: Wait for config-service to start
+        run: sleep 5
+
+      #apiGateway-Service Build & Docker Push
+      - name: Build with Gradle - apiGateway
+        run: |
+          cd apiGateway-service
+          ./gradlew clean build -x test
+          docker build -t ${{ secrets.DOCKERHUB_USERNAME }}/waither-gateway .
+          docker push ${{ secrets.DOCKERHUB_USERNAME }}/waither-gateway
+          cd ..
+          
+      #Eureka Build & Docker Push
+      - name: Build with Gradle - Eureka
+        run: |
+          cd Eureka
+          ./gradlew clean build -x test 
+          docker build -t ${{ secrets.DOCKERHUB_USERNAME }}/waither-eureka .
+          docker push ${{ secrets.DOCKERHUB_USERNAME }}/waither-eureka
+          cd ..
+
+      #Noti-Service Build & Docker Push
+      - name: Build with Gradle - noti-service
+        run: |
+          cd noti-service
+          ./gradlew clean build -x test 
+          docker build -t ${{ secrets.DOCKERHUB_USERNAME }}/waither-noti .
+          docker push ${{ secrets.DOCKERHUB_USERNAME }}/waither-noti
+          cd ..
+
+      #User-Service Build & Docker Push
+      - name: Build with Gradle - user-service
+        run: |
+          cd user-service
+          ./gradlew clean build -x test 
+          docker build -t ${{ secrets.DOCKERHUB_USERNAME }}/waither-user .
+          docker push ${{ secrets.DOCKERHUB_USERNAME }}/waither-user
+          cd ..
+
+      #Weather-Service Build & Docker Push
+      - name: Build with Gradle - weather-service
+        run: |
+          cd weather-service
+          ./gradlew clean build -x test 
+          docker build -t ${{ secrets.DOCKERHUB_USERNAME }}/waither-weather .
+          docker push ${{ secrets.DOCKERHUB_USERNAME }}/waither-weather
+          cd ..
+  
+  deploy:
+    name : Connect to EC2 and re-run container
+    needs : build
+    runs-on : ubuntu-latest
+    steps:
+      - name: Deploy to Server
+        uses: appleboy/ssh-action@v0.1.6
+        env:
+          SERVICE_NAME: ${{ github.event.inputs.service }}
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USERNAME }}
+          password: ${{ secrets.EC2_PASSWORD }}
+          port: ${{ secrets.EC2_SSH_PORT }}
+          timeout: 60s
+          script: |
+            export CONFIG_GIT_URI = ${{ secrets.DOCKERHUB_IMAGENAME }}
+            export CONFIG_PASSPHRASE = ${{ secrets.CONFIG_PASSPHRASE }}
+            export CONFIG_PRIVATE_KEY = ${{ secrets.CONFIG_PRIVATE_KEY }}
+
+            bash /home/docker_init.sh
+            bash /home/common.sh
+            bash /home/deploy.sh "${SERVICE_NAME}"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,23 +1,23 @@
 name: Backend CI/CD with Gradle
 
 on:
-  workflow_dispatch:
-    inputs:
-      service:
-        description: 'Choose Service to deploy. Default is all.'
-        required: true
-        default: 'all'
-        type: choice
-        options:
-        - all
-        - api-gateway
-        - noti-service
-        - user-service
-        - weather-service
-  # push:
-  #   branches:
-  #     - cicd/#61
-  #     - prod
+  # workflow_dispatch:
+  #   inputs:
+  #     service:
+  #       description: 'Choose Service to deploy. Default is all.'
+  #       required: true
+  #       default: 'all'
+  #       type: choice
+  #       options:
+  #       - all
+  #       - api-gateway
+  #       - noti-service
+  #       - user-service
+  #       - weather-service
+  push:
+    branches:
+      - cicd/#61
+      - prod
 
 jobs:
   build:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -126,7 +126,7 @@ jobs:
       - name: Deploy to Server
         uses: appleboy/ssh-action@v0.1.6
         env:
-          SERVICE_NAME: "all"
+          SERVICE_NAME: all
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USERNAME }}
@@ -137,6 +137,7 @@ jobs:
             export CONFIG_GIT_URI=${{ secrets.CONFIG_GIT_URI }}
             export CONFIG_PASSPHRASE=${{ secrets.CONFIG_PASSPHRASE }}
             export CONFIG_PRIVATE_KEY=${{ secrets.CONFIG_PRIVATE_KEY }}
+            export DOCKERHUB_USERNAME=${{ secrets.DOCKERHUB_USERNAME }}
 
             bash /home/docker_init.sh
             bash /home/common.sh

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -135,7 +135,7 @@ jobs:
           script: |
             export CONFIG_GIT_URI=${{ secrets.CONFIG_GIT_URI }}
             export CONFIG_PASSPHRASE=${{ secrets.CONFIG_PASSPHRASE }}
-            export CONFIG_PRIVATE_KEY=${{ secrets.CONFIG_PRIVATE_KEY }}
+            export CONFIG_PRIVATE_KEY=${{ secrets.CONFIG_PRIVATE_KEY_DIR }}
             export DOCKERHUB_USERNAME=${{ secrets.DOCKERHUB_USERNAME }}
 
             bash /home/docker_init.sh

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -4,9 +4,16 @@ on:
   workflow_dispatch:
     inputs:
       service:
-        description: 'Service to deploy. Default is all \n options : \n - api-gateway \n - noti-service \n - user-service \n - weather-service \n - all'
+        description: 'Choose Service to deploy. Default is all.'
         required: true
         default: 'all'
+        type: choice
+        options:
+        - all
+        - api-gateway
+        - noti-service
+        - user-service
+        - weather-service
   # push:
   #   branches:
   #     - cicd/#61

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -134,9 +134,9 @@ jobs:
           port: ${{ secrets.EC2_SSH_PORT }}
           timeout: 60s
           script: |
-            export CONFIG_GIT_URI = ${{ secrets.CONFIG_GIT_URI }}
-            export CONFIG_PASSPHRASE = ${{ secrets.CONFIG_PASSPHRASE }}
-            export CONFIG_PRIVATE_KEY = ${{ secrets.CONFIG_PRIVATE_KEY }}
+            export CONFIG_GIT_URI=${{ secrets.CONFIG_GIT_URI }}
+            export CONFIG_PASSPHRASE=${{ secrets.CONFIG_PASSPHRASE }}
+            export CONFIG_PRIVATE_KEY=${{ secrets.CONFIG_PRIVATE_KEY }}
 
             bash /home/docker_init.sh
             bash /home/common.sh

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -16,7 +16,6 @@ on:
   #       - weather-service
   push:
     branches:
-      - cicd/#61
       - prod
 
 jobs:
@@ -141,4 +140,4 @@ jobs:
 
             bash /home/docker_init.sh
             bash /home/common.sh
-            bash /home/deploy.sh "${SERVICE_NAME}"
+            bash /home/deploy.sh

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -126,7 +126,7 @@ jobs:
       - name: Deploy to Server
         uses: appleboy/ssh-action@v0.1.6
         env:
-          SERVICE_NAME: ${{ github.event.inputs.service }}
+          SERVICE_NAME: "all"
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USERNAME }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,8 @@
 name: Backend CI
 
 on:
-  pull_request:
+  push:
+  # pull_request:
     branches:
       - prod
       - develop

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
       - cicd/#61
 
 jobs:
-  build:
+  build-test:
     runs-on: ubuntu-latest
 
     steps:
@@ -23,7 +23,11 @@ jobs:
           distribution: 'temurin'
 
       - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
+        run: |
+          chmod +x ./config-service/gradlew
+          chmod +x ./noti-service/gradlew
+          chmod +x ./user-service/gradlew
+          chmod +x ./weather-service/gradlew
 
       - name: Build with Gradle - config
         run: ./config-service/gradlew clean build -x test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: Backend CI
+
+on:
+  pull_request:
+    branches:
+      - prod
+      - develop
+      - cicd/#61
+    types: [opened, synchronize]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: action checkout
+        uses: actions/checkout@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build with Gradle - config
+        run: ./config-service/gradlew clean build -x test
+        env:
+          CONFIG_GIT_URI: ${{ secrets.CONFIG_GIT_URI }}
+          CONFIG_PASSPHRASE: ${{ secrets.CONFIG_PASSPHRASE }}
+          CONFIG_PRIVATE_KEY: ${{ secrets.CONFIG_PRIVATE_KEY }}
+          

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           ls -all
           cd config-service
-          gradlew clean build -x test |& tee config-build.log
+          ./gradlew clean build -x test |& tee config-build.log
           cat config-build.log
         env:
           CONFIG_GIT_URI: ${{ secrets.CONFIG_GIT_URI }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,10 @@
 name: Backend CI
 
 on:
-  push:
-  # pull_request:
+  pull_request:
     branches:
       - prod
       - develop
-      - cicd/#61
 
 jobs:
   build-test:
@@ -32,8 +30,7 @@ jobs:
       - name: Build with Gradle - config
         run: |
           cd config-service
-          ./gradlew clean build -x test |& tee config-build.log
-          cat config-build.log
+          ./gradlew clean build -x test 
         env:
           CONFIG_GIT_URI: ${{ secrets.CONFIG_GIT_URI }}
           CONFIG_PASSPHRASE: ${{ secrets.CONFIG_PASSPHRASE }}
@@ -50,20 +47,17 @@ jobs:
       - name: Build with Gradle - noti-service
         run: |
           cd noti-service
-          ./gradlew clean build -x test |& tee noti-build.log
-          cat noti-build.log
+          ./gradlew clean build -x test 
           cd ..
   
       - name: Build with Gradle - user-service
         run: |
           cd user-service
-          ./gradlew clean build -x test |& tee user-build.log
-          cat user-build.log
+          ./gradlew clean build -x test 
           cd ..
   
       - name: Build with Gradle - weather-service
         run: |
           cd weather-service
-          ./gradlew clean build -x test |& tee user-build.log
-          cat user-build.log
+          ./gradlew clean build -x test 
           cd ..

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,9 @@ jobs:
 
       - name: Build with Gradle - config
         run: |
-          ./config-service/gradlew clean build -x test |& tee config-build.log
+          ls -all
+          cd config-service
+          gradlew clean build -x test |& tee config-build.log
           cat config-build.log
         env:
           CONFIG_GIT_URI: ${{ secrets.CONFIG_GIT_URI }}
@@ -39,7 +41,7 @@ jobs:
           CONFIG_PRIVATE_KEY: ${{ secrets.CONFIG_PRIVATE_KEY }}
         
       - name: Run config-service
-        run: ./config-service/gradlew bootRun &
+        run: gradlew bootRun &
 
       - name: Wait for config-service to start
         run: sleep 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,6 @@ on:
       - prod
       - develop
       - cicd/#61
-    types: [opened, synchronize]
 
 jobs:
   build:
@@ -32,4 +31,18 @@ jobs:
           CONFIG_GIT_URI: ${{ secrets.CONFIG_GIT_URI }}
           CONFIG_PASSPHRASE: ${{ secrets.CONFIG_PASSPHRASE }}
           CONFIG_PRIVATE_KEY: ${{ secrets.CONFIG_PRIVATE_KEY }}
-          
+        
+      - name: Run config-service
+        run: ./config-service/gradlew bootRun &
+
+      - name: Wait for config-service to start
+        run: sleep 5
+  
+      - name: Build with Gradle - noti-service
+        run: ./noti-service/gradlew clean build -x test
+  
+      - name: Build with Gradle - user-service
+        run: ./user-service/gradlew clean build -x test
+  
+      - name: Build with Gradle - weather-service
+        run: ./weather-service/gradlew clean build -x test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,9 @@ jobs:
           chmod +x ./weather-service/gradlew
 
       - name: Build with Gradle - config
-        run: ./config-service/gradlew clean build -x test
+        run: |
+          ./config-service/gradlew clean build -x test |& tee config-build.log
+          cat config-build.log
         env:
           CONFIG_GIT_URI: ${{ secrets.CONFIG_GIT_URI }}
           CONFIG_PASSPHRASE: ${{ secrets.CONFIG_PASSPHRASE }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,6 @@ jobs:
 
       - name: Build with Gradle - config
         run: |
-          ls -all
           cd config-service
           ./gradlew clean build -x test |& tee config-build.log
           cat config-build.log
@@ -41,16 +40,30 @@ jobs:
           CONFIG_PRIVATE_KEY: ${{ secrets.CONFIG_PRIVATE_KEY }}
         
       - name: Run config-service
-        run: gradlew bootRun &
+        run: |
+          ./gradlew bootRun &
+          cd ..
 
       - name: Wait for config-service to start
         run: sleep 5
   
       - name: Build with Gradle - noti-service
-        run: ./noti-service/gradlew clean build -x test
+        run: |
+          cd noti-service
+          ./gradlew clean build -x test |& tee noti-build.log
+          cat noti-build.log
+          cd ..
   
       - name: Build with Gradle - user-service
-        run: ./user-service/gradlew clean build -x test
+        run: |
+          cd user-service
+          ./gradlew clean build -x test |& tee user-build.log
+          cat user-build.log
+          cd ..
   
       - name: Build with Gradle - weather-service
-        run: ./weather-service/gradlew clean build -x test
+        run: |
+          cd weather-service
+          ./gradlew clean build -x test |& tee user-build.log
+          cat user-build.log
+          cd ..

--- a/Eureka/Dockerfile
+++ b/Eureka/Dockerfile
@@ -1,0 +1,5 @@
+FROM openjdk:17-jdk
+
+ARG JAR_FILE=build/libs/*.jar
+COPY ${JAR_FILE} app.jar
+ENTRYPOINT ["java", "-Dspring.profiles.active=prod", "-Duser.timezone=Asia/Seoul" , "-jar", "app.jar"]

--- a/Eureka/build.gradle
+++ b/Eureka/build.gradle
@@ -11,6 +11,10 @@ java {
     sourceCompatibility = '17'
 }
 
+jar {
+    enabled = false
+}
+
 repositories {
     mavenCentral()
 }

--- a/apiGateway-service/Dockerfile
+++ b/apiGateway-service/Dockerfile
@@ -1,0 +1,5 @@
+FROM openjdk:17-jdk
+
+ARG JAR_FILE=build/libs/*.jar
+COPY ${JAR_FILE} app.jar
+ENTRYPOINT ["java", "-Dspring.profiles.active=prod", "-Duser.timezone=Asia/Seoul" , "-jar", "app.jar"]

--- a/apiGateway-service/build.gradle
+++ b/apiGateway-service/build.gradle
@@ -11,6 +11,10 @@ java {
     sourceCompatibility = '17'
 }
 
+jar {
+    enabled = false
+}
+
 repositories {
     mavenCentral()
 }

--- a/apiGateway-service/src/main/java/com/waither/apigatewayservice/ApiGatewayServiceApplication.java
+++ b/apiGateway-service/src/main/java/com/waither/apigatewayservice/ApiGatewayServiceApplication.java
@@ -2,11 +2,9 @@ package com.waither.apigatewayservice;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.Bean;
-import org.springframework.security.config.web.server.ServerHttpSecurity;
-import org.springframework.security.web.server.SecurityWebFilterChain;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = {DataSourceAutoConfiguration.class})
 public class ApiGatewayServiceApplication {
 
     public static void main(String[] args) {

--- a/apiGateway-service/src/main/resources/bootstrap.yml
+++ b/apiGateway-service/src/main/resources/bootstrap.yml
@@ -1,5 +1,5 @@
 server:
-  port: 8000
+  port: 80
 
 spring:
   application:

--- a/config-service/Dockerfile
+++ b/config-service/Dockerfile
@@ -1,0 +1,5 @@
+FROM openjdk:17-jdk
+
+ARG JAR_FILE=build/libs/*.jar
+COPY ${JAR_FILE} app.jar
+ENTRYPOINT ["java", "-Dspring.profiles.active=prod", "-Duser.timezone=Asia/Seoul" , "-jar", "app.jar"]

--- a/config-service/build.gradle
+++ b/config-service/build.gradle
@@ -11,6 +11,10 @@ java {
     sourceCompatibility = '17'
 }
 
+jar {
+    enabled = false
+}
+
 repositories {
     mavenCentral()
 }

--- a/config-service/src/main/resources/bootstrap.yml
+++ b/config-service/src/main/resources/bootstrap.yml
@@ -6,3 +6,11 @@ spring:
     active: dev
   application:
     name: config-service
+  cloud:
+    config:
+      server:
+        git:
+          uri: ${CONFIG_GIT_URI}
+          ignore-local-ssh-settings: true
+          passphrase: ${CONFIG_PASSPHRASE}
+          private-key: ${CONFIG_PRIVATE_KEY}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,4 +71,19 @@ services:
     volumes:
       - /home/ec2-user/logs/noti-service:/logs
         
-
+  zookeeper:
+    image: wurstmeister/zookeeper:latest
+    container_name: zookeeper
+    ports:
+      - "2181:2181"
+      -
+  kafka:
+    image: wurstmeister/kafka:latest
+    container_name: kafka
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_ADVERTISED_HOST_NAME: 127.0.0.1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,74 @@
+version: '3'
+
+services:
+
+#  nginx:
+#    container_name: nginx
+#    image: nginx:latest
+#    ports:
+#      - "80:80"
+#    volumes:
+#      - /home/ec2-user/nginx.conf:/etc/nginx/nginx.conf
+#    depends_on:
+#      - "db"
+#    restart: always #항상 재실행
+
+  api-gateway:
+    container_name: api-gateway
+    image: ${DOCKERHUB_USERNAME}/waither-gateway
+    expose:
+      - "8000"
+    restart: always
+    volumes:
+      - /home/ec2-user/logs/api-gateway:/logs
+
+  config:
+    container_name: config
+    image: ${DOCKERHUB_USERNAME}/waither-config
+    expose:
+      - "8888"
+    environment:
+      CONFIG_GIT_URI : ${CONFIG_GIT_URI}
+      CONFIG_PASSPHRASE : ${CONFIG_PASSPHRASE}
+      CONFIG_PRIVATE_KEY : ${CONFIG_PRIVATE_KEY}
+    restart: always
+    volumes:
+      - /home/ec2-user/logs/config:/logs
+
+  eureka:
+    container_name: eureka
+    image: ${DOCKERHUB_USERNAME}/waither-eureka
+    expose:
+      - "8761"
+    restart: always
+    volumes:
+      - /home/ec2-user/logs/eureka:/logs
+
+  user-service:
+    container_name: user-service
+    image: ${DOCKERHUB_USERNAME}/waither-user
+    expose:
+      - "8080"
+    restart: unless-stopped #수동으로 중지되지 않는 이상 항상 재실행
+    volumes:
+      - /home/ec2-user/logs/user-service:/logs
+
+  weather-service:
+    container_name: weather-service
+    image: ${DOCKERHUB_USERNAME}/waither-weather
+    expose:
+      - "8081"
+    restart: unless-stopped
+    volumes:
+      - /home/ec2-user/logs/weather-service:/logs
+
+  noti-service:
+    container_name: noti-service
+    image: ${DOCKERHUB_USERNAME}/waither-noti
+    expose:
+      - "8082"
+    restart: unless-stopped
+    volumes:
+      - /home/ec2-user/logs/noti-service:/logs
+        
+

--- a/noti-service/Dockerfile
+++ b/noti-service/Dockerfile
@@ -1,0 +1,5 @@
+FROM openjdk:17-jdk
+
+ARG JAR_FILE=build/libs/*.jar
+COPY ${JAR_FILE} app.jar
+ENTRYPOINT ["java", "-Dspring.profiles.active=prod", "-Duser.timezone=Asia/Seoul" , "-jar", "app.jar"]

--- a/noti-service/build.gradle
+++ b/noti-service/build.gradle
@@ -12,6 +12,10 @@ java {
     sourceCompatibility = '17'
 }
 
+jar {
+    enabled = false
+}
+
 repositories {
     mavenCentral()
 }

--- a/script/common.sh
+++ b/script/common.sh
@@ -1,0 +1,21 @@
+# 현재 실행중인 도커 컨테이너중 단어가 포함 컨테이너를 검색
+RUNNING_EUREKA=$(docker ps | grep eureka)
+RUNNING_CONFIG=$(docker ps | grep config)
+
+# Eureka 검색
+if [ -z "$RUNNING_EUREKA" ]; then
+    echo "Starting Eureka ..."
+    docker compose -f /home/docker-compose.yml up -d eureka
+    sleep 5 #Eureka 실행 5초 대기
+else
+    echo "Eureka is already running"
+fi
+
+# Config 검색
+if [ -z "$RUNNING_CONFIG" ]; then
+    echo "Starting Config Service ..."
+    docker compose -f /home/docker-compose.yml up -d config
+    sleep 5 #Config 실행 5초 대기
+else
+    echo "Config Service is already running"
+fi

--- a/script/common.sh
+++ b/script/common.sh
@@ -1,6 +1,8 @@
 # 현재 실행중인 도커 컨테이너중 단어가 포함 컨테이너를 검색
 RUNNING_EUREKA=$(docker ps | grep eureka)
 RUNNING_CONFIG=$(docker ps | grep config)
+RUNNING_ZOOKEEPER=$(docker ps | grep zookeeper)
+RUNNING_KAFKA=$(docker ps | grep kafka)
 
 # Eureka 검색
 if [ -z "$RUNNING_EUREKA" ]; then
@@ -18,4 +20,20 @@ if [ -z "$RUNNING_CONFIG" ]; then
     sleep 5 #Config 실행 5초 대기
 else
     echo "Config Service is already running"
+fi
+
+# Zookeeper 검색
+if [ -z "$RUNNING_ZOOKEEPER" ]; then
+    echo "Starting Zookeeper ..."
+    docker compose -f /home/docker-compose.yml up -d zookeeper
+else
+    echo "Zookeeper is already running"
+fi
+
+# Kafka 검색
+if [ -z "$RUNNING_ZOOKEEPER" ]; then
+    echo "Starting Kafka ..."
+    docker compose -f /home/docker-compose.yml up -d kafka
+else
+    echo "Kafka is already running"
 fi

--- a/script/deploy.sh
+++ b/script/deploy.sh
@@ -1,36 +1,19 @@
 #!/bin/bash
 #셔뱅(shebang)
 
-# 입력받은 서비스 이름
-SERVICE_NAME=$1
-
-# 서비스 이름에 따라 배포할 컨테이너 이름 설정
-case "$SERVICE_NAME" in
-  "api-gateway")
-    TARGET_SERVICE="api-gateway"
-    ;;
-  "noti-service")
-    TARGET_SERVICE="noti-service"
-    ;;
-  "user-service")
-    TARGET_SERVICE="user-service"
-    ;;
-  "weather-service")
-    TARGET_SERVICE="weather-service"
-    ;;
-  "all")
-    TARGET_SERVICE="api-gateway noti-service user-service weather-service"
-    ;;
-  *)
-    echo "Invalid service name: $SERVICE_NAME"
-    exit 1
-    ;;
-esac
 
 # 타겟 서비스 재배포 시작
-echo "$TARGET_SERVICE Deploy..."
+#echo "$TARGET_SERVICE Deploy..."
 # docker compose 를 실행함.
 # -f 옵션 : docker-compose 명령에서 사용할 compose 파일의 경로를 지정. (file)
 # up : docker-compose 컨테이너를 시작하는 명령. 지정된 서비스의 컨테이너를 빌드, 생성 및 시작 (버전 최신화)
 # -d : detached 모드. 컨테이너를 백그라운드에서 실행
-docker compose -f /home/docker-compose.yml up -d $TARGET_SERVICE
+
+echo "api-gateway server start..."
+docker compose -f /home/docker-compose.yml up -d api-gateway
+echo "noti-service server start..."
+docker compose -f /home/docker-compose.yml up -d noti-service
+echo "user-service server start..."
+docker compose -f /home/docker-compose.yml up -d user-service
+echo "weather-service server start..."
+docker compose -f /home/docker-compose.yml up -d weather-service

--- a/script/deploy.sh
+++ b/script/deploy.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+#셔뱅(shebang)
+
+# 입력받은 서비스 이름
+SERVICE_NAME=$1
+
+# 서비스 이름에 따라 배포할 컨테이너 이름 설정
+case "$SERVICE_NAME" in
+  "api-gateway")
+    TARGET_SERVICE="api-gateway"
+    ;;
+  "noti-service")
+    TARGET_SERVICE="noti-service"
+    ;;
+  "user-service")
+    TARGET_SERVICE="user-service"
+    ;;
+  "weather-service")
+    TARGET_SERVICE="weather-service"
+    ;;
+  "all")
+    TARGET_SERVICE="api-gateway noti-service user-service weather-service"
+    ;;
+  *)
+    echo "Invalid service name: $SERVICE_NAME"
+    exit 1
+    ;;
+esac
+
+# 타겟 서비스 재배포 시작
+echo "$TARGET_SERVICE Deploy..."
+# docker compose 를 실행함.
+# -f 옵션 : docker-compose 명령에서 사용할 compose 파일의 경로를 지정. (file)
+# up : docker-compose 컨테이너를 시작하는 명령. 지정된 서비스의 컨테이너를 빌드, 생성 및 시작 (버전 최신화)
+# -d : detached 모드. 컨테이너를 백그라운드에서 실행
+docker compose -f /home/docker-compose.yml up -d $TARGET_SERVICE

--- a/script/docker_init.sh
+++ b/script/docker_init.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+#셔뱅(shebang) : 이 스크립트가 Bash Shell 에서 실행되어야 함을 나타냄.
+
+# Docker install
+#Docker 명령어가 존재하는지 확인함.
+# -v 옵션 : 명령어 실행 전 명령어와 인자 출력.
+# &> 명령어 출력과 오류 메세지를 리다이렉션. /dev/null 디바이스로 리다이렉션함.
+# docker 명령어의 경로를 출력하고(stdout), 발생할 수 있는 오류 메세지(stderr)와 함께 /dev/null 디바이스로 리다이렉션.
+# /dev/null 은 특수한 디바이스 파일. 쓰기 작업을 수행할 수 있지만 모든 데이터를 버림.
+# 즉, 명령어의 출력과 오류 메세지를 모두 숨길 수 있음.
+# 결론적으로 명령어의 존재 여부를 확인. 또는 명령어 실행 결괄르 사용하지 않고 성공/실패 여부만 확인하게 됨.
+if ! command -v docker &> /dev/null; then
+    # docker 명령어가 실패했을 경우 -> docker 가 설치되어 있지 않음. docker 설치를 진행함.
+    echo "Docker is not installed..."
+    echo "Docker install start..."
+    # yum : Red Hat 기반의 Linux 배포판에서 사용되는 패키지 관리 도구. 업데이트.
+    # 원래는 dnf 사용했지만 yum 으로 대체되고 있음.
+    sudo yum update -y
+    # docker 설치
+    sudo yum install -y docker
+    # docker 권한 설정
+    sudo usermod -aG docker ec2-user
+    sudo systemctl enable --now docker
+    echo "Docker install complete"
+else
+    # Docker 명령어가 성공했을 경우. Docker 가 이미 설치됨을 출력
+    echo "Docker is already installed"
+fi
+
+# Docker-compose install
+# Docker-compose 설치
+if ! command -v docker compose &> /dev/null; then
+    echo "Docker-compose is not installed..."
+    echo "Docker-compose install start..."
+
+    #Docker compose plugin 설치 - Amazon Linux 2023
+    sudo mkdir -p /usr/local/lib/docker/cli-plugins/
+    sudo curl -SL "https://github.com/docker/compose/releases/latest/download/docker-compose-linux-$(uname -m)" -o /usr/local/lib/docker/cli-plugins/docker-compose
+    sudo chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
+
+    docker compose version
+
+    echo "Docker-compose install complete!"
+else
+    echo "Docker-compose is already installed"
+fi

--- a/user-service/Dockerfile
+++ b/user-service/Dockerfile
@@ -1,0 +1,5 @@
+FROM openjdk:17-jdk
+
+ARG JAR_FILE=build/libs/*.jar
+COPY ${JAR_FILE} app.jar
+ENTRYPOINT ["java", "-Dspring.profiles.active=prod", "-Duser.timezone=Asia/Seoul" , "-jar", "app.jar"]

--- a/user-service/build.gradle
+++ b/user-service/build.gradle
@@ -12,6 +12,10 @@ java {
     sourceCompatibility = '17'
 }
 
+jar {
+    enabled = false
+}
+
 configurations {
     compileOnly {
         extendsFrom annotationProcessor

--- a/weather-service/Dockerfile
+++ b/weather-service/Dockerfile
@@ -1,0 +1,5 @@
+\FROM openjdk:17-jdk
+
+ARG JAR_FILE=build/libs/*.jar
+COPY ${JAR_FILE} app.jar
+ENTRYPOINT ["java", "-Dspring.profiles.active=prod", "-Duser.timezone=Asia/Seoul" , "-jar", "app.jar"]

--- a/weather-service/Dockerfile
+++ b/weather-service/Dockerfile
@@ -1,4 +1,4 @@
-\FROM openjdk:17-jdk
+FROM openjdk:17-jdk
 
 ARG JAR_FILE=build/libs/*.jar
 COPY ${JAR_FILE} app.jar

--- a/weather-service/build.gradle
+++ b/weather-service/build.gradle
@@ -12,6 +12,10 @@ java {
     sourceCompatibility = '17'
 }
 
+jar {
+    enabled = false
+}
+
 repositories {
     mavenCentral()
 }


### PR DESCRIPTION
# ☝️Issue Number

- #61 

# 🔎 Key Changes
- 빌드 테스트 (CI) 스크립트 작성
- docker-compose 작성
- common.sh / docker_init.sh / deploy.sh 작성
- AWS EC2, RDS 생성과 연결
- Private Key, 쉘 스크립트, docker-compose 주입
- CI/CD 스크립트 작성
- 각 서비스 Dockerfile생성
- 각 서비스 jar disabled
- api-Gateway 포트 80으로 변경(임시)

# 💌 To Reviewers
- 빌드 테스트 (CI) 는 develop, prod 브랜치 PR 생성시 실행됩니다.
예시 -> https://github.com/WaitherTeam/Waither-BE/actions/runs/9207208379
- CI/CD 는 Prod 브랜치 push시 실행됩니다.
- docker_init.sh : docker와 docker_compose가 설치되어있는지 확인하고, 설치되어 있지 않다면 설치합니다.
- common.sh : Eureka, Config Service - 기본적으로 로직이 변경되지 않는 서비스들을 배포합니다. 이미 실행중이라면 다시 바꾸지 않습니다.
- deploy.sh : Eureka, Config 를 제외한 나머지 서비스들을 배포합니다. 이미 컨테이너가 실행중이더라도 재실행합니다.

- 블루/그린 배포를 시도했지만 4 서비스 모두 블루/그린 하려다 보니 너무 복잡해져서 하지 않음
- 프록시 서버로 NGINX를 배치하려 했지만 apiGateway가 로드밸런서 역할을 하니 두지 않아도 되겠다고 판단
